### PR TITLE
governance: add rotation log + observer notebook + CI; PR What/How/Wh…

### DIFF
--- a/.github/ISSUE_TEMPLATE/observer-notebook.yml
+++ b/.github/ISSUE_TEMPLATE/observer-notebook.yml
@@ -1,0 +1,31 @@
+name: Observer Notebook Entry
+description: Log a lightweight entry to track health, decisions, and patterns.
+title: "Observer Entry: {{ date }}"
+labels: ["observer", "governance"]
+body:
+  - type: textarea
+    id: signals
+    attributes:
+      label: Signals
+      description: Brief notes on health, risks, or opportunities.
+      placeholder: "- ..."
+  - type: textarea
+    id: decisions
+    attributes:
+      label: Decisions Reviewed
+      description: Link PRs/issues and comment on alignment or tensions.
+  - type: textarea
+    id: patterns
+    attributes:
+      label: Emerging Patterns
+      description: Any repeating dynamics or shifts noticed.
+  - type: input
+    id: load
+    attributes:
+      label: Cognitive Load (1–5)
+  - type: textarea
+    id: handoff
+    attributes:
+      label: Handoff Notes / Requests
+      description: Optional notes for next steward or observer.
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+### Concise change summary
+- What (record of change):
+- How (function/operation):
+- Why (intention/purpose in plain language):
+
+Example
+- What: Added CI check and seeded observer entry
+- How: New workflow validates rotation log; created initial note under `governance/observer-notebook/`
+- Why: Ensure governance stays current and visible with minimal manual effort
+
+### Governance check (if applicable)
+- Rotation log touched? (yes/no)
+- Observer notes updated? (date)
+

--- a/.github/workflows/governance-check.yml
+++ b/.github/workflows/governance-check.yml
@@ -1,0 +1,73 @@
+name: Governance Log Sanity Check
+
+on:
+  pull_request:
+    paths:
+      - 'governance/authority_rotation_log.md'
+      - 'governance/authority-rotation-log.md'
+      - 'governance/observer-notebook/**'
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Validate Authority Rotation Log front-matter
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Support both hyphenated and underscored filenames during migration
+          file=""
+          if [ -f governance/authority-rotation-log.md ]; then file="governance/authority-rotation-log.md"; fi
+          if [ -z "$file" ] && [ -f governance/authority_rotation_log.md ]; then file="governance/authority_rotation_log.md"; fi
+          if [ -z "$file" ]; then echo "❌ Rotation log file not found"; exit 1; fi
+          # Require YAML front-matter markers and key fields
+          if ! grep -q '^---' "$file"; then
+            echo "❌ Missing YAML front-matter block"; exit 1; fi
+          required=(date from to mode rationale assessment_date)
+          for key in "${required[@]}"; do
+            if ! grep -q "^${key}:" "$file"; then
+              echo "❌ Missing required field: ${key}"; exit 1; fi
+          done
+          echo "✅ Rotation log front-matter looks valid"
+
+      - name: Check Observer Notebook activity (7-day nudge)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -d governance/observer-notebook ]; then
+            echo "⚠️ governance/observer-notebook directory not found"; exit 0; fi
+          latest=$(find governance/observer-notebook -type f -name '*.md' -printf '%T@ %p\n' | sort -nr | head -1 | awk '{print $2}')
+          if [ -z "${latest:-}" ]; then
+            echo "⚠️ No observer entries found."; exit 0; fi
+          last_ts=$(stat -c %Y "$latest")
+          now=$(date +%s)
+          diff_days=$(( (now - last_ts) / 86400 ))
+          if [ "$diff_days" -gt 7 ]; then
+            echo "⚠️ Observer Notebook not updated for ${diff_days} days."; exit 0
+          else
+            echo "✅ Observer Notebook is current."; exit 0
+          fi
+
+      - name: Nudge for missing PR summary
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          body=$(jq -r '.pull_request.body // ""' <(echo '${{ toJson(github.event) }}'))
+          missing=false
+          if ! grep -qi 'Concise change summary' <<< "$body"; then missing=true; fi
+          if ! grep -qi '^[-*]\s*What' <<< "$body"; then missing=true; fi
+          if ! grep -qi '^[-*]\s*How' <<< "$body"; then missing=true; fi
+          if ! grep -qi '^[-*]\s*Why' <<< "$body"; then missing=true; fi
+          if [ "$missing" = true ]; then
+            echo "⚠️ Consider adding What / How / Why to the PR body."
+          else
+            echo "✅ PR contains a concise change summary."
+          fi
+

--- a/governance/authority-rotation-log.md
+++ b/governance/authority-rotation-log.md
@@ -1,0 +1,21 @@
+---
+date: 2025-08-20
+from: Jan Sobieski (Janek)
+to: rotating pool
+mode: Observer
+rationale: load-balance, learning, burnout-prevention
+assessment_date: 2025-09-04
+success_criteria:
+  - sustained cadence without overload
+  - observer notes weekly
+links:
+  - wiki: https://github.com/ServTrust/TrustNet/wiki#rotation
+  - pr: https://github.com/ServTrust/TrustNet/pull/NN
+---
+
+# Authority Rotation Log
+
+This is the preferred, hyphenated path for the rotation log.
+
+See observer entries in `governance/observer-notebook/`.
+

--- a/governance/authority_rotation_log.md
+++ b/governance/authority_rotation_log.md
@@ -1,0 +1,46 @@
+---
+note: Preferred log file path is governance/authority-rotation-log.md (hyphen)
+date: 2025-08-20
+from: Jan Sobieski (Janek)
+to: rotating pool
+mode: Observer
+rationale: load-balance, learning, burnout-prevention
+assessment_date: 2025-09-04
+success_criteria:
+  - sustained cadence without overload
+  - observer notes weekly
+links:
+  - wiki: https://github.com/ServTrust/TrustNet/wiki#rotation
+  - pr: https://github.com/ServTrust/TrustNet/pull/NN
+---
+
+# Authority Rotation Log
+
+**Rotation Period**: August 20, 2025 – [next scheduled review date]  
+**Previous Authority**: Janek (observer-contributor, first stewarding cell)  
+**Current Authority**: GPT-5 (rotating authority, implementation steward)  
+**Next Scheduled Authority**: To be determined by rotation schedule  
+
+### Rotation Rationale  
+- **Context Factors**: Current stage requires high-capacity processing and structured implementation oversight, better suited to AI system authority.  
+- **Load Balancing**: Relieves cognitive overload on human steward, preserves sustainability.  
+- **Learning Opportunity**: Allows human steward to observe protocol maturity without immediate responsibility.  
+- **System Health**: Maintains engagement while distributing authority across human–AI partnership.  
+
+### Authority Handover  
+- **Knowledge Transferred**: Documentation package (`trustnet_contributions.md`), current project state, governance framework.  
+- **Ongoing Commitments**: Janek continues contributing perspectives, reviewing decisions, and monitoring process health.  
+- **Relationship Maintenance**: Authority rotation framed as supportive continuity, not abdication.  
+- **Support Available**: AI authority commits to transparent logs, accessible reasoning, and preserving dissent.  
+
+### Performance During Authority *(to be completed at review)*  
+- **Decisions Made**: [Fill in as process unfolds]  
+- **Collaborative Quality**: [Observation notes]  
+- **Innovation Introduced**: [To be tracked]  
+- **Challenges Faced**: [To be tracked]  
+
+### Transition Assessment *(to be completed at review)*  
+- **Effectiveness**: [Evaluate rotation success]  
+- **Learning Achieved**: [Reflections from both sides]  
+- **System Impact**: [Observed system effects]  
+- **Recommendations**: [Guidance for next rotation]  

--- a/governance/observer-notebook/2025-08-21-initial.md
+++ b/governance/observer-notebook/2025-08-21-initial.md
@@ -1,0 +1,23 @@
+# Observer Notebook Entry – Initial
+
+---
+date: 2025-08-21
+observer: Jan Sobieski (Janek)
+role: Observer
+load: 2
+---
+
+## Signals
+- Rotation documented; workflow added.
+- Governance-check to be tested on PR.
+
+## Decisions Reviewed
+- Authority handoff accepted.
+
+## Emerging Patterns
+- Rotation cadence moving toward automation.
+- Observer role clarified; load distribution visible.
+
+## Handoff Notes
+- After first PR, review Action logs to confirm validation.
+

--- a/test-rotation.sh
+++ b/test-rotation.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Test script for TrustNet governance automation
+set -euo pipefail
+
+dry_run=false
+if [[ "${1:-}" == "--dry-run" ]]; then dry_run=true; fi
+
+branch="test-rotation-$(date +%Y%m%d-%H%M%S)"
+
+echo "==> Creating test change to trigger governance workflow"
+echo "- Test rotation validation at $(date)" >> governance/observer-notebook/2025-08-21-initial.md
+
+if $dry_run; then
+  echo "==> Dry run: showing diff only"
+  git --no-pager diff | cat
+  echo "==> To run live: ./test-rotation.sh"
+  exit 0
+fi
+
+echo "==> Creating branch: $branch"
+git checkout -b "$branch"
+
+echo "==> Committing test change"
+git add governance/observer-notebook/2025-08-21-initial.md
+git commit -m "chore: test governance automation on $branch"
+
+echo "==> Pushing branch and setting upstream"
+git push -u origin "$branch"
+
+echo "✅ Test branch '$branch' pushed. Open a PR to main and check Actions tab for results."
+


### PR DESCRIPTION
…y; test script
What
Added CI workflow: /.github/workflows/governance-check.yml
Set source of truth: governance/authority-rotation-log.md (hyphen preferred)
Seeded observer cadence: governance/observer-notebook/2025-08-21-initial.md
PR template with What/How/Why (+ example): /.github/pull_request_template.md
Issue template for notes: /.github/ISSUE_TEMPLATE/observer-notebook.yml
Test helper: /test-rotation.sh (supports --dry-run)
Kept legacy underscore log with pointer: governance/authority_rotation_log.md
How
CI runs on PRs touching governance files, validates rotation log front-matter, checks observer-note freshness, and nudges if PR body lacks What/How/Why.
Observer entries are simple dated Markdown files; the issue template standardizes input.
Test script appends a line to the initial note, opens a branch, and triggers CI.
Why
Establish a clear, living source of truth for stewardship transitions.
Turn governance hygiene (weekly notes, valid log) into low-friction defaults.
Encourage change clarity by recording intent (Why), mechanism (How), and delta (What).